### PR TITLE
Fix link error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install::
 
 # LLVM
 LLVM_CXXFLAGS:=`llvm-config --cxxflags`
-LLVM_LDFLAGS:=`llvm-config --ldflags`
+LLVM_LDFLAGS:=`llvm-config --ldflags --system-libs`
 LLVM_LIBS:=`llvm-config --libs`
 
 # compiler customization


### PR DESCRIPTION
Maybe this is due differences between LLVM versions, but on my system, `llvm-config --ldflags` doesn't include system libs.